### PR TITLE
Fix users-and-roles client build type errors

### DIFF
--- a/src/microfrontends/users-and-roles/client/components/UserEngagementChart.tsx
+++ b/src/microfrontends/users-and-roles/client/components/UserEngagementChart.tsx
@@ -26,12 +26,12 @@ const UserEngagementChart: React.FC<UserEngagementChartProps> = ({ data }) => {
     paper_bgcolor: 'transparent',
     plot_bgcolor: 'transparent',
     xaxis: {
-      title: 'Week',
+      title: { text: 'Week' },
       zeroline: false,
       gridcolor: 'rgba(148, 163, 184, 0.2)',
     },
     yaxis: {
-      title: 'Activity',
+      title: { text: 'Activity' },
       zeroline: false,
       gridcolor: 'rgba(148, 163, 184, 0.2)',
     },

--- a/src/microfrontends/users-and-roles/client/index.tsx
+++ b/src/microfrontends/users-and-roles/client/index.tsx
@@ -87,7 +87,7 @@ const UsersList: React.FC<UsersListProps> = ({ users, isLoading, error }) => {
   );
 
   return (
-    <Space className="users-roles__section" direction="vertical" size="large" align="stretch">
+    <Space className="users-roles__section" direction="vertical" size="large">
       <div>
         <Title level={2}>Users and roles</Title>
         <Paragraph>
@@ -142,7 +142,7 @@ const UserDetails: React.FC<UserDetailsProps> = ({ users, isLoading }) => {
 
   if (!user) {
     return (
-      <Space className="users-roles__section" direction="vertical" size="large" align="stretch">
+      <Space className="users-roles__section" direction="vertical" size="large">
         <Button
           type="link"
           className="users-roles__back-button"
@@ -190,7 +190,7 @@ const UserDetails: React.FC<UserDetailsProps> = ({ users, isLoading }) => {
   ];
 
   return (
-    <Space className="users-roles__section" direction="vertical" size="large" align="stretch">
+    <Space className="users-roles__section" direction="vertical" size="large">
       <Button
         type="link"
         className="users-roles__back-button"

--- a/src/types/plotly.js.d.ts
+++ b/src/types/plotly.js.d.ts
@@ -1,0 +1,5 @@
+declare module 'plotly.js/dist/plotly' {
+  import type { PlotlyStatic } from 'plotly.js';
+  const Plotly: PlotlyStatic;
+  export default Plotly;
+}


### PR DESCRIPTION
## Summary
- remove unsupported Ant Design Space alignment settings that caused type errors
- adjust Plotly axis title definitions to use structured title objects
- declare the plotly.js runtime bundle module to provide typings for the client chart

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7fe1722648324a199a7cb82123340