### PR TITLE
Harden shell proxy registration and align reports API prefix

### DIFF
--- a/src/microfrontends/operations-reports/client/hooks/useReportsData.ts
+++ b/src/microfrontends/operations-reports/client/hooks/useReportsData.ts
@@ -34,7 +34,7 @@ const normalizeApiPrefix = (prefix: string | null | undefined, fallback: string)
 };
 
 const manifestApiPrefix = (manifest as ManifestWithApiPrefix).api?.prefix ?? null;
-const API_PREFIX = normalizeApiPrefix(manifestApiPrefix, '/api/mf/operations-reports');
+const API_PREFIX = normalizeApiPrefix(manifestApiPrefix, '/api/mf/reports');
 
 const buildApiUrl = (path: string) => {
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;

--- a/src/microfrontends/operations-reports/manifest.json
+++ b/src/microfrontends/operations-reports/manifest.json
@@ -6,7 +6,7 @@
   "entryPath": "/operations-reports.js",
   "description": "Analytics and readiness metrics prepared by the operations reporting team.",
   "api": {
-    "prefix": "/api/mf/operations-reports",
+    "prefix": "/api/mf/reports",
     "target": "/api"
   }
 }


### PR DESCRIPTION
## Summary
- add process-level logging for unhandled promise rejections and uncaught exceptions in the shell server
- refactor microfrontend proxy registration to use http-proxy-middleware path filtering and rewriting while keeping shell /api endpoints local
- update the operations reports microfrontend to serve its API from `/api/mf/reports`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d91fae09ac83248375e1d53f2d2670