### PR TITLE
Refactor shell server and fix microfrontend proxy

### DIFF
--- a/src/shell-app/server/lib/env.js
+++ b/src/shell-app/server/lib/env.js
@@ -1,0 +1,99 @@
+const path = require('path');
+
+const DEFAULT_RESPONSE_DELAY_MS = 300;
+
+const parsePort = (value, fallback) => {
+  const parsed = Number.parseInt(String(value ?? '').trim(), 10);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const parseDelayMs = (value, fallback) => {
+  const parsed = Number.parseInt(String(value ?? '').trim(), 10);
+
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const normalizeHost = (host) => {
+  const trimmed = String(host ?? '').trim();
+
+  return trimmed && trimmed !== '0.0.0.0' ? trimmed : 'localhost';
+};
+
+const resolveClientDevServerUrl = ({ explicitUrl, host, port }) => {
+  const normalizedExplicitUrl = String(explicitUrl ?? '').trim();
+
+  if (normalizedExplicitUrl) {
+    return normalizedExplicitUrl;
+  }
+
+  const normalizedHost = normalizeHost(host);
+  const normalizedPort = parsePort(port, 4301);
+
+  return `http://${normalizedHost}:${normalizedPort}`;
+};
+
+const parseProxyTarget = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+
+    if (!url.protocol || !url.host) {
+      return null;
+    }
+
+    return url.toString().replace(/\/$/, '');
+  } catch (_error) {
+    return null;
+  }
+};
+
+const resolveClientDistDirectory = ({ explicitDistPath, serverDir }) => {
+  if (explicitDistPath) {
+    return path.resolve(explicitDistPath);
+  }
+
+  return path.resolve(serverDir, '..', 'client', 'dist');
+};
+
+const createEnvironment = ({ env, serverDir }) => {
+  const port = parsePort(env.SHELL_PORT, 4300);
+  const host = String(env.SHELL_HOST ?? '0.0.0.0');
+  const responseDelayMs = parseDelayMs(env.SERVER_RESPONSE_DELAY_MS, DEFAULT_RESPONSE_DELAY_MS);
+  const clientHost = String(env.CLIENT_HOST ?? '0.0.0.0');
+  const clientPort = parsePort(env.CLIENT_PORT, 4301);
+  const clientDevServerUrl = resolveClientDevServerUrl({
+    explicitUrl: env.CLIENT_DEV_SERVER_URL,
+    host: clientHost,
+    port: clientPort,
+  });
+  const clientDevServerTarget = parseProxyTarget(clientDevServerUrl);
+  const distDir = resolveClientDistDirectory({
+    explicitDistPath: env.CLIENT_DIST_DIR,
+    serverDir,
+  });
+
+  return {
+    clientDevServerTarget,
+    clientDevServerUrl,
+    distDir,
+    host,
+    isProduction: env.NODE_ENV === 'production',
+    port,
+    responseDelayMs,
+  };
+};
+
+module.exports = {
+  DEFAULT_RESPONSE_DELAY_MS,
+  createEnvironment,
+  normalizeHost,
+  parseDelayMs,
+  parsePort,
+  parseProxyTarget,
+  resolveClientDevServerUrl,
+  resolveClientDistDirectory,
+};

--- a/src/shell-app/server/lib/microfrontend-proxy.js
+++ b/src/shell-app/server/lib/microfrontend-proxy.js
@@ -1,0 +1,66 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const { createPathRewriter } = require('./proxy-config');
+
+const createMicrofrontendProxyManager = ({ app }) => {
+  if (!app) {
+    throw new Error('Express app instance is required to create the proxy manager.');
+  }
+
+  const proxyRegistry = new Map();
+
+  const register = (entry) => {
+    const config = entry?.apiProxy;
+
+    if (!config) {
+      return;
+    }
+
+    const existing = proxyRegistry.get(config.prefix);
+
+    if (existing) {
+      if (existing.target === config.target && existing.pathRewrite === config.pathRewrite) {
+        return;
+      }
+
+      console.warn(
+        `Proxy for prefix ${config.prefix} is already registered; skipping conflicting registration`,
+      );
+      return;
+    }
+
+    const rewritePath = createPathRewriter(config.prefix, config.pathRewrite);
+    const filter = (pathname) => typeof pathname === 'string' && pathname.startsWith(config.prefix);
+    const proxyMiddleware = createProxyMiddleware(filter, {
+      changeOrigin: true,
+      logLevel: 'warn',
+      pathRewrite: (path) => rewritePath(path),
+      target: config.target,
+      ws: true,
+    });
+
+    app.use(proxyMiddleware);
+    app.on('upgrade', proxyMiddleware.upgrade);
+
+    proxyRegistry.set(config.prefix, {
+      middleware: proxyMiddleware,
+      pathRewrite: config.pathRewrite,
+      target: config.target,
+    });
+
+    const targetPathSuffix = config.pathRewrite === '/' ? '' : config.pathRewrite;
+    console.log(
+      `Proxying microfrontend API requests from ${config.prefix} to ${config.target}${targetPathSuffix}`,
+    );
+  };
+
+  const unregister = (prefix) => {
+    proxyRegistry.delete(prefix);
+  };
+
+  return {
+    register,
+    unregister,
+  };
+};
+
+module.exports = { createMicrofrontendProxyManager };

--- a/src/shell-app/server/lib/proxy-config.js
+++ b/src/shell-app/server/lib/proxy-config.js
@@ -1,0 +1,74 @@
+const ensureLeadingSlash = (value) => {
+  if (typeof value !== 'string') {
+    return '/';
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '/';
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+};
+
+const normalizeProxyPrefix = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const withLeadingSlash = ensureLeadingSlash(trimmed);
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+
+  if (!withoutTrailingSlash || withoutTrailingSlash === '/') {
+    return null;
+  }
+
+  return withoutTrailingSlash;
+};
+
+const normalizeProxyRewrite = (value) => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+
+  if (!trimmed || trimmed === '/') {
+    return '/';
+  }
+
+  const withLeadingSlash = ensureLeadingSlash(trimmed);
+  const withoutTrailingSlash = withLeadingSlash.replace(/\/+$/, '');
+
+  return withoutTrailingSlash || '/';
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|\[\]\\]/g, '\\$&');
+
+const createPathRewriter = (prefix, rewriteBase) => {
+  const escapedPrefix = escapeRegex(prefix);
+  const matcher = new RegExp(`^${escapedPrefix}`);
+  const normalizedBase = rewriteBase === '/' ? '/' : normalizeProxyRewrite(rewriteBase);
+
+  return (path) => {
+    const stripped = path.replace(matcher, '');
+
+    if (!stripped || stripped === '/') {
+      return normalizedBase;
+    }
+
+    const suffix = stripped.startsWith('/') ? stripped : `/${stripped}`;
+
+    if (normalizedBase === '/') {
+      return suffix === '/' ? '/' : suffix;
+    }
+
+    return suffix === '/' ? normalizedBase : `${normalizedBase}${suffix}`;
+  };
+};
+
+module.exports = {
+  createPathRewriter,
+  ensureLeadingSlash,
+  normalizeProxyPrefix,
+  normalizeProxyRewrite,
+};

--- a/src/shell-app/server/lib/registry.js
+++ b/src/shell-app/server/lib/registry.js
@@ -1,0 +1,143 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  ensureLeadingSlash,
+  normalizeProxyPrefix,
+  normalizeProxyRewrite,
+} = require('./proxy-config');
+
+const ensureDirectory = (directory) => {
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+};
+
+const ensureDataFile = ({ dataFile, sourceDataFile }) => {
+  ensureDirectory(path.dirname(dataFile));
+
+  if (!fs.existsSync(dataFile) && sourceDataFile && fs.existsSync(sourceDataFile)) {
+    fs.copyFileSync(sourceDataFile, dataFile);
+  }
+};
+
+const sanitizeApiProxyConfig = (value) => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const prefix = normalizeProxyPrefix(value.prefix);
+  const target = typeof value.target === 'string' ? value.target.trim() : '';
+
+  if (!prefix || !target) {
+    return null;
+  }
+
+  const pathRewrite = normalizeProxyRewrite(value.pathRewrite);
+
+  return {
+    pathRewrite,
+    prefix,
+    target,
+  };
+};
+
+const sanitizeRegistryEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+
+  const id = typeof entry.id === 'string' ? entry.id.trim() : '';
+
+  if (!id) {
+    return null;
+  }
+
+  const name = typeof entry.name === 'string' ? entry.name : id;
+  const menuLabel = typeof entry.menuLabel === 'string' ? entry.menuLabel : name;
+  const routePath = ensureLeadingSlash(entry.routePath || '/');
+  const entryUrl = typeof entry.entryUrl === 'string' ? entry.entryUrl : '';
+  const description = typeof entry.description === 'string' ? entry.description : '';
+  const manifestUrl =
+    typeof entry.manifestUrl === 'string' && entry.manifestUrl.trim()
+      ? entry.manifestUrl
+      : null;
+  const lastAcknowledgedAt =
+    typeof entry.lastAcknowledgedAt === 'string' ? entry.lastAcknowledgedAt : null;
+
+  if (!entryUrl) {
+    return null;
+  }
+
+  return {
+    apiProxy: sanitizeApiProxyConfig(entry.apiProxy),
+    description,
+    entryUrl,
+    id,
+    lastAcknowledgedAt,
+    manifestUrl,
+    menuLabel,
+    name,
+    routePath,
+  };
+};
+
+const loadRegistryEntries = (dataFile) => {
+  try {
+    const raw = fs.readFileSync(dataFile, 'utf-8');
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map(sanitizeRegistryEntry)
+      .filter((entry) => entry && entry.id && entry.entryUrl);
+  } catch (_error) {
+    return [];
+  }
+};
+
+const createMicrofrontendRegistry = ({ dataFile, sourceDataFile }) => {
+  if (!dataFile) {
+    throw new Error('dataFile is required to create the microfrontend registry.');
+  }
+
+  ensureDataFile({ dataFile, sourceDataFile });
+  const registry = new Map(loadRegistryEntries(dataFile).map((entry) => [entry.id, entry]));
+
+  const values = () => Array.from(registry.values());
+  const get = (id) => registry.get(id);
+  const set = (entry) => {
+    if (!entry || !entry.id) {
+      throw new Error('Entry with a valid id is required to store in the registry.');
+    }
+
+    registry.set(entry.id, entry);
+  };
+  const remove = (id) => {
+    const existing = registry.get(id);
+    registry.delete(id);
+    return existing;
+  };
+  const persist = () => {
+    ensureDataFile({ dataFile, sourceDataFile });
+    const serialized = JSON.stringify(values(), null, 2);
+    fs.writeFileSync(dataFile, serialized);
+  };
+
+  return {
+    dataFile,
+    get,
+    persist,
+    remove,
+    set,
+    values,
+  };
+};
+
+module.exports = {
+  createMicrofrontendRegistry,
+  sanitizeApiProxyConfig,
+  sanitizeRegistryEntry,
+};

--- a/src/shell-app/server/lib/request-logger.js
+++ b/src/shell-app/server/lib/request-logger.js
@@ -1,0 +1,14 @@
+const createRequestLogger = (label) => (req, res, next) => {
+  const start = Date.now();
+
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    const url = req.originalUrl || req.url;
+
+    console.log(`[${label}] ${req.method} ${url} -> ${res.statusCode} (${duration}ms)`);
+  });
+
+  next();
+};
+
+module.exports = { createRequestLogger };

--- a/src/shell-app/server/lib/utils.js
+++ b/src/shell-app/server/lib/utils.js
@@ -1,0 +1,17 @@
+const delay = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const cloneDeep = (value) => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+
+  return JSON.parse(JSON.stringify(value));
+};
+
+module.exports = {
+  cloneDeep,
+  delay,
+};


### PR DESCRIPTION
## Summary
- modularize the shell server by extracting environment, proxy, registry, and utility helpers
- fix microfrontend proxy registration and update reports endpoint handling
- keep shell API responses and acknowledgement flow consistent while reusing shared helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d978078ee88324b387c03cff08eca1