### PR TITLE
Update proxy middleware usage for http-proxy-middleware v3

### DIFF
--- a/src/shell-app/server/lib/microfrontend-proxy.js
+++ b/src/shell-app/server/lib/microfrontend-proxy.js
@@ -29,10 +29,12 @@ const createMicrofrontendProxyManager = ({ app }) => {
     }
 
     const rewritePath = createPathRewriter(config.prefix, config.pathRewrite);
-    const filter = (pathname) => typeof pathname === 'string' && pathname.startsWith(config.prefix);
-    const proxyMiddleware = createProxyMiddleware(filter, {
+    const pathFilter = (pathname) =>
+      typeof pathname === 'string' && pathname.startsWith(config.prefix);
+    const proxyMiddleware = createProxyMiddleware({
       changeOrigin: true,
       logLevel: 'warn',
+      pathFilter,
       pathRewrite: (path) => rewritePath(path),
       target: config.target,
       ws: true,

--- a/src/shell-app/server/shell-server.js
+++ b/src/shell-app/server/shell-server.js
@@ -205,9 +205,10 @@ if (environment.isProduction) {
 } else if (environment.clientDevServerTarget) {
   const shouldProxyClientRequest = (url) => typeof url === 'string' && !url.startsWith('/api');
   const pathFilter = (requestPath) => shouldProxyClientRequest(requestPath);
-  const clientProxy = createProxyMiddleware(pathFilter, {
+  const clientProxy = createProxyMiddleware({
     changeOrigin: true,
     logLevel: 'warn',
+    pathFilter,
     target: environment.clientDevServerTarget,
     ws: true,
   });


### PR DESCRIPTION
## Summary
- update the microfrontend proxy manager to use the config-only signature required by http-proxy-middleware v3
- adjust the shell development proxy to register via the same v3-compatible API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d97fadb68c8324af2a9df9b8710a7f