### PR TITLE
Expand shared React modules across federated bundles

### DIFF
--- a/src/microfrontends/common/webpack/createMicrofrontendConfig.cjs
+++ b/src/microfrontends/common/webpack/createMicrofrontendConfig.cjs
@@ -39,24 +39,33 @@ const normalizeModuleFederationName = (value) =>
     .replace(/^-/, '')
     .replace(/[^a-zA-Z0-9_]/g, '') || 'microfrontend';
 
-const createSharedConfig = (dependencies = {}) => {
-  const sharedLibraries = ['react', 'react-dom', 'react-router', 'react-router-dom'];
+const sharedLibraries = [
+  { shareKey: 'react', packageName: 'react' },
+  { shareKey: 'react-dom', packageName: 'react-dom' },
+  { shareKey: 'react-dom/client', packageName: 'react-dom' },
+  { shareKey: 'react/jsx-runtime', packageName: 'react' },
+  { shareKey: 'react/jsx-dev-runtime', packageName: 'react' },
+  { shareKey: 'react-router', packageName: 'react-router' },
+  { shareKey: 'react-router-dom', packageName: 'react-router-dom' },
+];
 
-  return sharedLibraries.reduce((shared, library) => {
-    const version = dependencies[library];
+const createSharedConfig = (dependencies = {}) =>
+  sharedLibraries.reduce((shared, { shareKey, packageName }) => {
+    const version = dependencies[packageName];
 
-    if (version) {
-      shared[library] = {
-        singleton: true,
-        eager: true,
-        shareScope: 'default',
-        requiredVersion: version,
-      };
+    if (!version) {
+      return shared;
     }
+
+    shared[shareKey] = {
+      singleton: true,
+      eager: true,
+      shareScope: 'default',
+      requiredVersion: version,
+    };
 
     return shared;
   }, {});
-};
 
 const createMicrofrontendConfig = ({
   rootDir,

--- a/src/shell-app/client/webpack.config.cjs
+++ b/src/shell-app/client/webpack.config.cjs
@@ -10,24 +10,33 @@ const statoscope = require('@statoscope/webpack-plugin');
 const { ModuleFederationPlugin } = container;
 const { dependencies = {} } = require('./package.json');
 
-const createSharedConfig = () => {
-  const libraries = ['react', 'react-dom', 'react-router', 'react-router-dom'];
+const sharedLibraries = [
+  { shareKey: 'react', packageName: 'react' },
+  { shareKey: 'react-dom', packageName: 'react-dom' },
+  { shareKey: 'react-dom/client', packageName: 'react-dom' },
+  { shareKey: 'react/jsx-runtime', packageName: 'react' },
+  { shareKey: 'react/jsx-dev-runtime', packageName: 'react' },
+  { shareKey: 'react-router', packageName: 'react-router' },
+  { shareKey: 'react-router-dom', packageName: 'react-router-dom' },
+];
 
-  return libraries.reduce((shared, library) => {
-    const version = dependencies[library];
+const createSharedConfig = () =>
+  sharedLibraries.reduce((shared, { shareKey, packageName }) => {
+    const version = dependencies[packageName];
 
-    if (version) {
-      shared[library] = {
-        singleton: true,
-        eager: true,
-        shareScope: 'default',
-        requiredVersion: version,
-      };
+    if (!version) {
+      return shared;
     }
+
+    shared[shareKey] = {
+      singleton: true,
+      eager: true,
+      shareScope: 'default',
+      requiredVersion: version,
+    };
 
     return shared;
   }, {});
-};
 
 const StatoscopeWebpackPlugin =
   statoscope && statoscope.default ? statoscope.default : statoscope;


### PR DESCRIPTION
## Summary
- extend the module federation shared configuration to cover additional React entry points
- ensure microfrontends and the shell reuse the same React runtime exports including react-dom/client and jsx runtimes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e105ef85bc8324812d1ec948e2874f