### PR TITLE
feat: add device security table page

### DIFF
--- a/src/shell-app/client/components/MainLayout.tsx
+++ b/src/shell-app/client/components/MainLayout.tsx
@@ -29,6 +29,7 @@ import { useMicrofrontends } from '../microfrontends/useMicrofrontends';
 import NotFound from '../pages/NotFound';
 import { useShellInitialization } from '../hooks/useShellInitialization';
 import WizardQuickSetupPage from '../pages/workshop/react-perf/WizardQuickSetupPage';
+import DeviceSecurityPage from '../pages/DeviceSecurityPage';
 
 interface ShellMenuItem {
   id: string;
@@ -53,6 +54,11 @@ const baseMenuSections: ShellMenuSection[] = [
         id: 'dashboard',
         title: 'Dashboard',
         path: '/dashboard',
+      },
+      {
+        id: 'device-security',
+        title: 'Device security',
+        path: '/device-security',
       },
     ],
   },
@@ -345,9 +351,13 @@ const MainLayout: React.FC = () => {
       path: '/',
       element: <Navigate to="/dashboard" replace />,
     },
-    {
+    { 
       path: '/dashboard',
       Component: Dashboard,
+    },
+    {
+      path: '/device-security',
+      Component: DeviceSecurityPage,
     },
     {
       path: '/workshop/react-perf/wizard',

--- a/src/shell-app/client/pages/DeviceSecurityPage.tsx
+++ b/src/shell-app/client/pages/DeviceSecurityPage.tsx
@@ -2,45 +2,60 @@ import React, { useMemo, useRef, useState } from 'react';
 import { Table, type TableColumn, type TablePaginationProps, type TableRecord } from '@kaspersky/hexa-ui';
 import { useAutoTrimCells } from '../shared/useAutoTrimCells';
 
+type AuditTrail = {
+  summary: string;
+  events: Array<{ ts: string; description: string; code: number }>;
+  raw: string;
+};
+
 type Row = TableRecord & {
   id: string;
   device: string;
-  policy: string;
+  policy: {
+    label: string;
+    audit: AuditTrail;
+  };
   status: string;
   lastSeen: string;
   vulns: number;
 };
 
+const PAGE_SIZE = 50;
+const TOTAL_ROWS = PAGE_SIZE * 40; // 40 страниц по 50 строк — достаточно для демонстрации утечки
+
+const createAuditTrail = (index: number): AuditTrail => ({
+  summary: `Baseline ${index % 7} applied`,
+  events: Array.from({ length: 60 }, (_, eIdx) => ({
+    ts: new Date(2025, index % 12, (eIdx % 28) + 1, eIdx % 24, eIdx % 60).toISOString(),
+    description: `Policy verification #${eIdx} for device ${index}`,
+    code: (index + eIdx * 17) % 997,
+  })),
+  raw: 'AUDIT_TRACE_FOR_DEVICE_' + index + ':'.padEnd(128, '=') + '::' + 'log-entry\n'.repeat(500),
+});
+
+const DEVICE_ROWS: Row[] = Array.from({ length: TOTAL_ROWS }, (_, i) => ({
+  id: `device-${i}`,
+  device: `WS-${1000 + i} · ${'Very long device name '.repeat((i % 4) + 1)}`,
+  policy: {
+    label: `Strict Baseline ${i % 7}`,
+    audit: createAuditTrail(i), // 🧱 тяжёлый объект утащит с собой мегабайты истории
+  },
+  status: i % 5 === 0 ? 'At Risk' : 'Compliant',
+  lastSeen: `2025-10-${(i % 28 + 1).toString().padStart(2, '0')} 12:${(i % 60)
+    .toString()
+    .padStart(2, '0')}`,
+  vulns: (i * 7) % 31,
+}));
+
 export default function DeviceSecurityPage() {
   const hostRef = useRef<HTMLDivElement | null>(null);
-  useAutoTrimCells(hostRef);
+  useAutoTrimCells(hostRef); // 😈 утечка: хук навсегда держит DOM-ячейки в Map
 
-  const [w1, setW1] = useState(180);
-  const [w2, setW2] = useState(240);
-  const [w3, setW3] = useState(140);
-  const [w4, setW4] = useState(160);
-  const [w5, setW5] = useState(120);
   const [page, setPage] = useState(0);
-  const pageSize = 40;
-
-  const data = useMemo<Row[]>(
-    () =>
-      Array.from({ length: 400 }, (_, i) => ({
-        id: `d${i}`,
-        device: `WS-${1000 + i} · ${'Very long device name '.repeat((i % 4) + 1)}`,
-        policy: `Strict Baseline ${i % 7}`,
-        status: i % 5 === 0 ? 'At Risk' : 'Compliant',
-        lastSeen: `2025-10-${(i % 28 + 1).toString().padStart(2, '0')} 12:${(i % 60)
-          .toString()
-          .padStart(2, '0')}`,
-        vulns: (i * 7) % 31,
-      })),
-    [],
-  );
 
   const pageData = useMemo<Row[]>(
-    () => data.slice(page * pageSize, (page + 1) * pageSize),
-    [data, page, pageSize],
+    () => DEVICE_ROWS.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [page],
   );
 
   const columns = useMemo<TableColumn[]>(
@@ -49,21 +64,24 @@ export default function DeviceSecurityPage() {
         key: 'device',
         dataIndex: 'device',
         title: 'Device',
-        width: w1,
+        width: 320,
         ellipsis: true,
       },
       {
         key: 'policy',
         dataIndex: 'policy',
         title: 'Policy',
-        width: w2,
+        width: 280,
         ellipsis: true,
+        render: (_value, record: Row) => (
+          <span title={record.policy.summary}>{record.policy.label}</span>
+        ),
       },
       {
         key: 'status',
         dataIndex: 'status',
         title: 'Status',
-        width: w3,
+        width: 180,
         render: (value: Row['status']) => (
           <span style={{ fontWeight: value === 'At Risk' ? 600 : 400 }}>{value}</span>
         ),
@@ -72,68 +90,36 @@ export default function DeviceSecurityPage() {
         key: 'lastSeen',
         dataIndex: 'lastSeen',
         title: 'Last Seen',
-        width: w4,
+        width: 220,
         ellipsis: true,
       },
       {
         key: 'vulns',
         dataIndex: 'vulns',
         title: 'Vulns',
-        width: w5,
+        width: 160,
         align: 'right',
       },
     ],
-    [w1, w2, w3, w4, w5],
+    [],
   );
 
   const pagination = useMemo<TablePaginationProps>(
     () => ({
-      pageSize,
+      pageSize: PAGE_SIZE,
       current: page + 1,
-      total: data.length,
+      total: DEVICE_ROWS.length,
       onChange: (nextPage) => setPage(nextPage - 1),
       showTotal: (total, range) => `${range[0]}-${range[1]} of ${total}`,
     }),
-    [data.length, page, pageSize],
+    [page],
   );
 
-  const totalWidth = w1 + w2 + w3 + w4 + w5;
+  const totalWidth = columns.reduce((sum, column) => sum + (column.width ?? 0), 0);
 
   return (
     <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 16 }}>
       <h2 style={{ margin: 0 }}>Безопасность устройств</h2>
-      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
-        <label>
-          Device
-          <input type="range" min={120} max={360} value={w1} onChange={(e) => setW1(Number(e.target.value))} />
-        </label>
-        <label>
-          Policy
-          <input type="range" min={140} max={360} value={w2} onChange={(e) => setW2(Number(e.target.value))} />
-        </label>
-        <label>
-          Status
-          <input type="range" min={100} max={240} value={w3} onChange={(e) => setW3(Number(e.target.value))} />
-        </label>
-        <label>
-          Last Seen
-          <input type="range" min={120} max={300} value={w4} onChange={(e) => setW4(Number(e.target.value))} />
-        </label>
-        <label>
-          Vulns
-          <input type="range" min={80} max={200} value={w5} onChange={(e) => setW5(Number(e.target.value))} />
-        </label>
-        <button type="button" onClick={() => setPage((p) => Math.max(0, p - 1))}>
-          Prev
-        </button>
-        <button
-          type="button"
-          onClick={() => setPage((p) => Math.min(Math.ceil(data.length / pageSize) - 1, p + 1))}
-        >
-          Next
-        </button>
-        <span>Page {page + 1}</span>
-      </div>
       <div ref={hostRef} style={{ border: '1px solid #333', borderRadius: 8, overflow: 'hidden' }}>
         <Table
           rowKey="id"

--- a/src/shell-app/client/pages/DeviceSecurityPage.tsx
+++ b/src/shell-app/client/pages/DeviceSecurityPage.tsx
@@ -1,0 +1,148 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Table, type TableColumn, type TablePaginationProps, type TableRecord } from '@kaspersky/hexa-ui';
+import { useAutoTrimCells } from '../shared/useAutoTrimCells';
+
+type Row = TableRecord & {
+  id: string;
+  device: string;
+  policy: string;
+  status: string;
+  lastSeen: string;
+  vulns: number;
+};
+
+export default function DeviceSecurityPage() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  useAutoTrimCells(hostRef);
+
+  const [w1, setW1] = useState(180);
+  const [w2, setW2] = useState(240);
+  const [w3, setW3] = useState(140);
+  const [w4, setW4] = useState(160);
+  const [w5, setW5] = useState(120);
+  const [page, setPage] = useState(0);
+  const pageSize = 40;
+
+  const data = useMemo<Row[]>(
+    () =>
+      Array.from({ length: 400 }, (_, i) => ({
+        id: `d${i}`,
+        device: `WS-${1000 + i} · ${'Very long device name '.repeat((i % 4) + 1)}`,
+        policy: `Strict Baseline ${i % 7}`,
+        status: i % 5 === 0 ? 'At Risk' : 'Compliant',
+        lastSeen: `2025-10-${(i % 28 + 1).toString().padStart(2, '0')} 12:${(i % 60)
+          .toString()
+          .padStart(2, '0')}`,
+        vulns: (i * 7) % 31,
+      })),
+    [],
+  );
+
+  const pageData = useMemo<Row[]>(
+    () => data.slice(page * pageSize, (page + 1) * pageSize),
+    [data, page, pageSize],
+  );
+
+  const columns = useMemo<TableColumn[]>(
+    () => [
+      {
+        key: 'device',
+        dataIndex: 'device',
+        title: 'Device',
+        width: w1,
+        ellipsis: true,
+      },
+      {
+        key: 'policy',
+        dataIndex: 'policy',
+        title: 'Policy',
+        width: w2,
+        ellipsis: true,
+      },
+      {
+        key: 'status',
+        dataIndex: 'status',
+        title: 'Status',
+        width: w3,
+        render: (value: Row['status']) => (
+          <span style={{ fontWeight: value === 'At Risk' ? 600 : 400 }}>{value}</span>
+        ),
+      },
+      {
+        key: 'lastSeen',
+        dataIndex: 'lastSeen',
+        title: 'Last Seen',
+        width: w4,
+        ellipsis: true,
+      },
+      {
+        key: 'vulns',
+        dataIndex: 'vulns',
+        title: 'Vulns',
+        width: w5,
+        align: 'right',
+      },
+    ],
+    [w1, w2, w3, w4, w5],
+  );
+
+  const pagination = useMemo<TablePaginationProps>(
+    () => ({
+      pageSize,
+      current: page + 1,
+      total: data.length,
+      onChange: (nextPage) => setPage(nextPage - 1),
+      showTotal: (total, range) => `${range[0]}-${range[1]} of ${total}`,
+    }),
+    [data.length, page, pageSize],
+  );
+
+  const totalWidth = w1 + w2 + w3 + w4 + w5;
+
+  return (
+    <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <h2 style={{ margin: 0 }}>Безопасность устройств</h2>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <label>
+          Device
+          <input type="range" min={120} max={360} value={w1} onChange={(e) => setW1(Number(e.target.value))} />
+        </label>
+        <label>
+          Policy
+          <input type="range" min={140} max={360} value={w2} onChange={(e) => setW2(Number(e.target.value))} />
+        </label>
+        <label>
+          Status
+          <input type="range" min={100} max={240} value={w3} onChange={(e) => setW3(Number(e.target.value))} />
+        </label>
+        <label>
+          Last Seen
+          <input type="range" min={120} max={300} value={w4} onChange={(e) => setW4(Number(e.target.value))} />
+        </label>
+        <label>
+          Vulns
+          <input type="range" min={80} max={200} value={w5} onChange={(e) => setW5(Number(e.target.value))} />
+        </label>
+        <button type="button" onClick={() => setPage((p) => Math.max(0, p - 1))}>
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(Math.ceil(data.length / pageSize) - 1, p + 1))}
+        >
+          Next
+        </button>
+        <span>Page {page + 1}</span>
+      </div>
+      <div ref={hostRef} style={{ border: '1px solid #333', borderRadius: 8, overflow: 'hidden' }}>
+        <Table
+          rowKey="id"
+          dataSource={pageData}
+          columns={columns}
+          pagination={pagination}
+          scroll={{ x: totalWidth }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/shell-app/client/shared/useAutoTrimCells.ts
+++ b/src/shell-app/client/shared/useAutoTrimCells.ts
@@ -1,0 +1,44 @@
+import { RefObject, useEffect } from 'react';
+
+const CELLS = new Map<HTMLElement, true>();
+const CELL_SELECTOR = 'th.ant-table-cell,td.ant-table-cell,[data-cell]';
+
+export function useAutoTrimCells(tableRef: RefObject<HTMLElement>) {
+  useEffect(() => {
+    const table = tableRef.current;
+    if (!table) return;
+
+    const obs = new ResizeObserver(() => {});
+
+    const add = (el: HTMLElement) => {
+      if (CELLS.has(el)) return;
+      CELLS.set(el, true);
+      obs.observe(el);
+    };
+
+    table.querySelectorAll<HTMLElement>(CELL_SELECTOR).forEach(add);
+
+    const mo = new MutationObserver((muts) => {
+      for (const m of muts) {
+        m.addedNodes.forEach((n) => {
+          if (n instanceof HTMLElement) {
+            if (n.matches?.(CELL_SELECTOR)) add(n);
+            n.querySelectorAll?.(CELL_SELECTOR).forEach((el) => add(el as HTMLElement));
+          }
+        });
+        m.removedNodes.forEach((n) => {
+          if (n instanceof HTMLElement) {
+            if (n.matches?.(CELL_SELECTOR)) obs.unobserve(n);
+            n.querySelectorAll?.(CELL_SELECTOR).forEach((el) => obs.unobserve(el as HTMLElement));
+          }
+        });
+      }
+    });
+    mo.observe(table, { childList: true, subtree: true });
+
+    return () => {
+      mo.disconnect();
+      obs.disconnect();
+    };
+  }, [tableRef]);
+}


### PR DESCRIPTION
## Summary
- add a device security sample page that renders Hexa UI table data with adjustable columns
- introduce the leaking auto trim hook and align its selectors with Hexa table cells
- register the new page in the shell navigation and routing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e107af141883249f2802cc82a2f039