### PR TITLE
Refactor microfrontends to use window externals

### DIFF
--- a/src/shell-app/client/main.tsx
+++ b/src/shell-app/client/main.tsx
@@ -1,9 +1,36 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import * as ReactDOMClient from 'react-dom/client';
+import * as ReactJSXRuntime from 'react/jsx-runtime';
+import * as ReactJSXDevRuntime from 'react/jsx-dev-runtime';
+import * as ReactRouter from 'react-router';
+import * as ReactRouterDOM from 'react-router-dom';
 import type { Metric } from 'web-vitals';
 import App from './App';
 import reportWebVitals from './metrics/reportWebVitals';
 import './styles.css';
+
+declare global {
+  interface Window {
+    React: typeof React;
+    ReactDOM: typeof ReactDOM;
+    ReactDOMClient: typeof ReactDOMClient;
+    ReactJSXRuntime: typeof ReactJSXRuntime;
+    ReactJSXDevRuntime: typeof ReactJSXDevRuntime;
+    ReactRouter: typeof ReactRouter;
+    ReactRouterDOM: typeof ReactRouterDOM;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.React = React;
+  window.ReactDOM = ReactDOM;
+  window.ReactDOMClient = ReactDOMClient;
+  window.ReactJSXRuntime = ReactJSXRuntime;
+  window.ReactJSXDevRuntime = ReactJSXDevRuntime;
+  window.ReactRouter = ReactRouter;
+  window.ReactRouterDOM = ReactRouterDOM;
+}
 
 const markPerformance = (label: string) => {
   if (typeof performance === 'undefined' || typeof performance.mark !== 'function') {


### PR DESCRIPTION
## Summary
- replace Module Federation sharing with window-based externals in the shared microfrontend webpack configuration
- expose React, React DOM, JSX runtimes, and React Router on the window object for shell applications

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14f42a5548324b613610dc1fbf987