### PR TITLE
Load microfrontends via registry and gate React Scan

### DIFF
--- a/src/microfrontends/operations-reports/client/index.tsx
+++ b/src/microfrontends/operations-reports/client/index.tsx
@@ -4,6 +4,17 @@ import OperationsReportsLayout from './routes/OperationsReportsLayout';
 import ReportDetails from './routes/ReportDetails';
 import ReportsList from './routes/ReportsList';
 
+type MicrofrontendRegistryEntry = {
+  default?: RouteObject;
+  routeConfig?: RouteObject;
+};
+
+declare global {
+  interface Window {
+    microfrontends?: Record<string, MicrofrontendRegistryEntry | undefined>;
+  }
+}
+
 export const operationsReportsRouteConfig: RouteObject = {
   path: '/reports',
   Component: OperationsReportsLayout,
@@ -18,5 +29,16 @@ export const operationsReportsRouteConfig: RouteObject = {
     },
   ],
 };
+
+if (typeof window !== 'undefined') {
+  const registry = (window.microfrontends ??= {});
+  const microfrontendId = 'reports-microfrontend';
+  const currentEntry = registry[microfrontendId] ?? {};
+
+  registry[microfrontendId] = {
+    ...currentEntry,
+    routeConfig: operationsReportsRouteConfig,
+  };
+}
 
 export default operationsReportsRouteConfig;

--- a/src/microfrontends/users-and-roles/client/index.tsx
+++ b/src/microfrontends/users-and-roles/client/index.tsx
@@ -5,6 +5,17 @@ import UsersAndRolesLayout from './routes/UsersAndRolesLayout';
 import UserDetails from './routes/UserDetails';
 import UsersList from './routes/UsersList';
 
+type MicrofrontendRegistryEntry = {
+  default?: RouteObject;
+  routeConfig?: RouteObject;
+};
+
+declare global {
+  interface Window {
+    microfrontends?: Record<string, MicrofrontendRegistryEntry | undefined>;
+  }
+}
+
 export const usersAndRolesRouteConfig: RouteObject = {
   path: '/users',
   Component: UsersAndRolesLayout,
@@ -23,5 +34,16 @@ export const usersAndRolesRouteConfig: RouteObject = {
     },
   ],
 };
+
+if (typeof window !== 'undefined') {
+  const registry = (window.microfrontends ??= {});
+  const microfrontendId = 'users-and-roles-microfrontend';
+  const currentEntry = registry[microfrontendId] ?? {};
+
+  registry[microfrontendId] = {
+    ...currentEntry,
+    routeConfig: usersAndRolesRouteConfig,
+  };
+}
 
 export default usersAndRolesRouteConfig;

--- a/src/shell-app/client/main.tsx
+++ b/src/shell-app/client/main.tsx
@@ -10,6 +10,8 @@ import App from './App';
 import reportWebVitals from './metrics/reportWebVitals';
 import './styles.css';
 
+declare const __REACT_SCAN_ENABLED__: boolean;
+
 declare global {
   interface Window {
     React: typeof React;
@@ -19,6 +21,7 @@ declare global {
     ReactJSXDevRuntime: typeof ReactJSXDevRuntime;
     ReactRouter: typeof ReactRouter;
     ReactRouterDOM: typeof ReactRouterDOM;
+    microfrontends?: Record<string, unknown>;
   }
 }
 
@@ -30,6 +33,17 @@ if (typeof window !== 'undefined') {
   window.ReactJSXDevRuntime = ReactJSXDevRuntime;
   window.ReactRouter = ReactRouter;
   window.ReactRouterDOM = ReactRouterDOM;
+  window.microfrontends = window.microfrontends ?? {};
+}
+
+if (typeof __REACT_SCAN_ENABLED__ !== 'undefined' && __REACT_SCAN_ENABLED__) {
+  void import('react-scan')
+    .then(({ scan }) => {
+      scan();
+    })
+    .catch((error) => {
+      console.error('Failed to initialize React Scan', error);
+    });
 }
 
 const markPerformance = (label: string) => {

--- a/src/shell-app/client/microfrontends/useMicrofrontends.ts
+++ b/src/shell-app/client/microfrontends/useMicrofrontends.ts
@@ -12,8 +12,110 @@ type MicrofrontendModule = {
   routeConfig?: RouteObject;
 };
 
-const loadMicrofrontendModule = async (entryUrl: string): Promise<MicrofrontendModule> =>
-  (await import(/* webpackIgnore: true */ entryUrl)) as MicrofrontendModule;
+declare global {
+  interface Window {
+    microfrontends?: Record<string, MicrofrontendModule | undefined>;
+  }
+}
+
+const scriptPromises = new Map<string, Promise<void>>();
+
+const loadScript = (entryUrl: string): Promise<void> => {
+  if (scriptPromises.has(entryUrl)) {
+    return scriptPromises.get(entryUrl)!;
+  }
+
+  const promise = new Promise<void>((resolve, reject) => {
+    if (typeof document === 'undefined') {
+      reject(new Error(`Cannot load script ${entryUrl} outside of a browser environment.`));
+      return;
+    }
+
+    const existingScript = Array.from(document.querySelectorAll<HTMLScriptElement>('script')).find(
+      (element) => {
+        if (element.getAttribute('data-microfrontend-entry') === entryUrl) {
+          return true;
+        }
+
+        if (!element.src) {
+          return false;
+        }
+
+        try {
+          const elementUrl = new URL(element.src, document.baseURI).href;
+          const requestedUrl = new URL(entryUrl, document.baseURI).href;
+
+          return elementUrl === requestedUrl;
+        } catch (error) {
+          console.warn('Unable to normalize microfrontend script URL', error);
+          return false;
+        }
+      },
+    );
+
+    if (existingScript) {
+      existingScript.setAttribute('data-microfrontend-entry', entryUrl);
+
+      if (
+        existingScript.dataset.microfrontendLoaded === 'true' ||
+        existingScript.readyState === 'complete'
+      ) {
+        resolve();
+        return;
+      }
+
+      const handleError = () => {
+        existingScript.removeEventListener('load', handleLoad);
+        existingScript.removeEventListener('error', handleError);
+        reject(new Error(`Failed to load microfrontend from ${entryUrl}.`));
+      };
+
+      const handleLoad = () => {
+        existingScript.dataset.microfrontendLoaded = 'true';
+        existingScript.removeEventListener('load', handleLoad);
+        existingScript.removeEventListener('error', handleError);
+        resolve();
+      };
+
+      existingScript.addEventListener('load', handleLoad);
+      existingScript.addEventListener('error', handleError);
+
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = entryUrl;
+    script.setAttribute('data-microfrontend-entry', entryUrl);
+
+    const handleLoad = () => {
+      script.dataset.microfrontendLoaded = 'true';
+      script.removeEventListener('load', handleLoad);
+      script.removeEventListener('error', handleError);
+      resolve();
+    };
+
+    const handleError = () => {
+      script.removeEventListener('load', handleLoad);
+      script.removeEventListener('error', handleError);
+      script.remove();
+      reject(new Error(`Failed to load microfrontend from ${entryUrl}.`));
+    };
+
+    script.addEventListener('load', handleLoad);
+    script.addEventListener('error', handleError);
+
+    document.head.appendChild(script);
+  });
+
+  scriptPromises.set(entryUrl, promise);
+
+  promise.catch(() => {
+    scriptPromises.delete(entryUrl);
+  });
+
+  return promise;
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -134,7 +236,24 @@ export const useMicrofrontends = (): UseMicrofrontendsResult => {
         const payload = parseMicrofrontends((await response.json()) as unknown);
         const loadedMicrofrontends = await Promise.all(
           payload.map(async (manifest) => {
-            const module = await loadMicrofrontendModule(manifest.entryUrl);
+            await loadScript(manifest.entryUrl);
+
+            const registry = window.microfrontends;
+
+            if (!registry) {
+              throw new Error(
+                `Microfrontend registry is unavailable after loading ${manifest.entryUrl}.`,
+              );
+            }
+
+            const module = registry[manifest.id];
+
+            if (!module) {
+              throw new Error(
+                `Microfrontend ${manifest.id} did not register itself on window.microfrontends.`,
+              );
+            }
+
             const routeConfig = resolveMicrofrontendRouteConfig(module, manifest.entryUrl);
 
             return {

--- a/src/shell-app/client/webpack.config.cjs
+++ b/src/shell-app/client/webpack.config.cjs
@@ -4,7 +4,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const { container } = require('webpack');
+const { container, DefinePlugin } = require('webpack');
 const statoscope = require('@statoscope/webpack-plugin');
 
 const { ModuleFederationPlugin } = container;
@@ -43,6 +43,7 @@ const StatoscopeWebpackPlugin =
 
 const isProduction = process.env.NODE_ENV === 'production';
 const shouldAnalyze = process.env.ANALYZE === 'true';
+const isReactScanEnabled = process.env.REACT_SCAN === 'true';
 
 const analyzerPlugins = () => {
   if (!shouldAnalyze) {
@@ -120,6 +121,9 @@ const config = {
     new ModuleFederationPlugin({
       name: 'shellApp',
       shared: createSharedConfig(),
+    }),
+    new DefinePlugin({
+      __REACT_SCAN_ENABLED__: JSON.stringify(isReactScanEnabled),
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '..', '..', '..', 'public', 'index.html'),


### PR DESCRIPTION
## Summary
- load microfrontend entry bundles with plain script tags and read their APIs from window.microfrontends
- register each microfrontend's route configuration on window.microfrontends when its entry executes
- expose a webpack define for REACT_SCAN and lazily import react-scan only when the flag is enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e15c9658e8832486d9ddcaff0864d3