### PR TITLE
refactor: migrate DeviceSecurityPage table to antd

### DIFF
--- a/src/shell-app/client/pages/DeviceSecurityPage.tsx
+++ b/src/shell-app/client/pages/DeviceSecurityPage.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useRef, useState } from 'react';
-import { Table, type TableColumn, type TablePaginationProps, type TableRecord } from '@kaspersky/hexa-ui';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
+import { Table } from 'antd';
 import { useAutoTrimCells } from '../shared/useAutoTrimCells';
 
 type AuditTrail = {
@@ -8,7 +9,7 @@ type AuditTrail = {
   raw: string;
 };
 
-type Row = TableRecord & {
+type Row = {
   id: string;
   device: string;
   policy: {
@@ -58,7 +59,7 @@ export default function DeviceSecurityPage() {
     [page],
   );
 
-  const columns = useMemo<TableColumn[]>(
+  const columns = useMemo<ColumnsType<Row>>(
     () => [
       {
         key: 'device',
@@ -73,7 +74,7 @@ export default function DeviceSecurityPage() {
         title: 'Policy',
         width: 280,
         ellipsis: true,
-        render: (_value, record: Row) => (
+        render: (_value, record) => (
           <span title={record.policy.summary}>{record.policy.label}</span>
         ),
       },
@@ -104,7 +105,7 @@ export default function DeviceSecurityPage() {
     [],
   );
 
-  const pagination = useMemo<TablePaginationProps>(
+  const pagination = useMemo<TablePaginationConfig>(
     () => ({
       pageSize: PAGE_SIZE,
       current: page + 1,


### PR DESCRIPTION
## Summary
- replace the Hexa UI table component with Ant Design's Table on the device security page
- update table column and pagination typings to align with Ant Design APIs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e16912786083249e7db31661c80b08