### PR TITLE
Add scripts to serve built microfrontend servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "nx": "nx",
     "build": "nx run-many --target=build --all",
+    "build:prod:run": "npm run build && nx run-many --target=serve-dist --projects shell-server,operations-reports-server,users-and-roles-server --parallel=3 --output-style=stream",
     "dev": "nx run-many --target=serve --projects shell-client,shell-server,operations-reports-client,operations-reports-server,users-and-roles-client,users-and-roles-server --parallel=6 --output-style=stream",
     "lint": "eslint --ext .ts,.tsx src",
     "format": "prettier --write .",

--- a/src/microfrontends/common/server/index.js
+++ b/src/microfrontends/common/server/index.js
@@ -32,10 +32,16 @@ const resolveClientDevServerUrl = ({ explicitUrl, host, port }) => {
   return `http://${normalizeHost(host)}:${port}`;
 };
 
+const resolveServerRoot = (serverDir) =>
+  path.basename(serverDir) === 'dist' ? path.resolve(serverDir, '..') : serverDir;
+
 const resolveClientDistDirectory = ({ explicitDistPath, serverDir }) => {
-  return explicitDistPath
-    ? path.resolve(explicitDistPath)
-    : path.resolve(serverDir, '..', 'client', 'dist');
+  const normalizedServerDir = resolveServerRoot(serverDir);
+  if (explicitDistPath) {
+    return path.resolve(normalizedServerDir, explicitDistPath);
+  }
+
+  return path.resolve(normalizedServerDir, '..', 'client', 'dist');
 };
 
 const createRequestLogger = (label) => (req, res, next) => {
@@ -106,4 +112,5 @@ module.exports = {
   registerClientAssetHandling,
   resolveClientDevServerUrl,
   resolveClientDistDirectory,
+  resolveServerRoot,
 };

--- a/src/microfrontends/operations-reports/server/package.json
+++ b/src/microfrontends/operations-reports/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "start": "node server.js",
+    "start:dist": "node scripts/start-dist.js",
     "dev": "nodemon --watch server.js --watch data --ext js,json --exec node server.js"
   },
   "dependencies": {

--- a/src/microfrontends/operations-reports/server/project.json
+++ b/src/microfrontends/operations-reports/server/project.json
@@ -17,6 +17,13 @@
         "cwd": "src/microfrontends/operations-reports/server",
         "command": "npm run dev"
       }
+    },
+    "serve-dist": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "src/microfrontends/operations-reports/server",
+        "command": "npm run start:dist"
+      }
     }
   },
   "tags": []

--- a/src/microfrontends/operations-reports/server/scripts/build.js
+++ b/src/microfrontends/operations-reports/server/scripts/build.js
@@ -4,6 +4,7 @@ const path = require('path');
 const projectRoot = __dirname;
 const distDir = path.resolve(projectRoot, '..', 'dist');
 const filesToCopy = ['server.js'];
+const directoriesToCopy = ['data', 'swagger'];
 
 const ensureDist = () => {
   if (fs.existsSync(distDir)) {
@@ -13,8 +14,26 @@ const ensureDist = () => {
   fs.mkdirSync(distDir, { recursive: true });
 };
 
-const copy = (source, destination) => {
+const copyFile = (source, destination) => {
   fs.copyFileSync(source, destination);
+};
+
+const copyDirectory = (source, destination) => {
+  if (!fs.existsSync(destination)) {
+    fs.mkdirSync(destination, { recursive: true });
+  }
+
+  for (const entry of fs.readdirSync(source)) {
+    const sourceEntry = path.join(source, entry);
+    const destinationEntry = path.join(destination, entry);
+    const stats = fs.statSync(sourceEntry);
+
+    if (stats.isDirectory()) {
+      copyDirectory(sourceEntry, destinationEntry);
+    } else {
+      fs.copyFileSync(sourceEntry, destinationEntry);
+    }
+  }
 };
 
 const build = () => {
@@ -24,7 +43,14 @@ const build = () => {
     const source = path.resolve(projectRoot, '..', file);
     const destination = path.join(distDir, file);
     if (fs.existsSync(source)) {
-      copy(source, destination);
+      copyFile(source, destination);
+    }
+  }
+
+  for (const directory of directoriesToCopy) {
+    const source = path.resolve(projectRoot, '..', directory);
+    if (fs.existsSync(source)) {
+      copyDirectory(source, path.join(distDir, directory));
     }
   }
 

--- a/src/microfrontends/operations-reports/server/scripts/start-dist.js
+++ b/src/microfrontends/operations-reports/server/scripts/start-dist.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const distEntry = path.resolve(__dirname, '..', 'dist', 'server.js');
+
+if (!fs.existsSync(distEntry)) {
+  console.error(
+    'Operations reports server build output not found. Please run "npm run build" first.',
+  );
+  process.exit(1);
+}
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+require(distEntry);

--- a/src/microfrontends/operations-reports/server/server.js
+++ b/src/microfrontends/operations-reports/server/server.js
@@ -1,13 +1,20 @@
 const path = require('path');
 
-require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+const resolveServerRoot = (directory) =>
+  path.basename(directory) === 'dist' ? path.resolve(directory, '..') : directory;
+
+const SERVER_DIR = resolveServerRoot(__dirname);
+const PROJECT_ROOT = path.resolve(SERVER_DIR, '..');
+const COMMON_ROOT = path.resolve(PROJECT_ROOT, '..', 'common');
+
+require('dotenv').config({ path: path.resolve(PROJECT_ROOT, '.env') });
 
 const express = require('express');
-const manifest = require('../manifest.json');
+const manifest = require(path.resolve(PROJECT_ROOT, 'manifest.json'));
 const {
   buildMicrofrontendDescriptor,
   createMicrofrontendAcknowledger,
-} = require('../../common/bootstrap');
+} = require(path.resolve(COMMON_ROOT, 'bootstrap.js'));
 const {
   createRequestLogger,
   createResponseDelayMiddleware,
@@ -16,10 +23,14 @@ const {
   registerClientAssetHandling,
   resolveClientDevServerUrl,
   resolveClientDistDirectory,
-} = require('../../common/server');
+} = require(path.resolve(COMMON_ROOT, 'server'));
 const swaggerUi = require('swagger-ui-express');
-const apiDocumentation = require('./swagger/reports-api.json');
-const { reports } = require('./data/reports');
+const apiDocumentation = require(path.resolve(
+  SERVER_DIR,
+  'swagger',
+  'reports-api.json',
+));
+const { reports } = require(path.resolve(SERVER_DIR, 'data', 'reports.js'));
 
 const MICROFRONT_PORT = parsePort(process.env.MICROFRONT_PORT, 4400);
 const MICROFRONT_HOST = String(process.env.MICROFRONT_HOST ?? '0.0.0.0');
@@ -39,7 +50,7 @@ const CLIENT_DEV_SERVER_URL = resolveClientDevServerUrl({
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,
-  serverDir: __dirname,
+  serverDir: SERVER_DIR,
 });
 
 const app = express();

--- a/src/microfrontends/users-and-roles/server/package.json
+++ b/src/microfrontends/users-and-roles/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "start": "node server.js",
+    "start:dist": "node scripts/start-dist.js",
     "dev": "nodemon --watch server.js --watch data --ext js,json --exec node server.js"
   },
   "dependencies": {

--- a/src/microfrontends/users-and-roles/server/project.json
+++ b/src/microfrontends/users-and-roles/server/project.json
@@ -17,6 +17,13 @@
         "cwd": "src/microfrontends/users-and-roles/server",
         "command": "npm run dev"
       }
+    },
+    "serve-dist": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "src/microfrontends/users-and-roles/server",
+        "command": "npm run start:dist"
+      }
     }
   },
   "tags": []

--- a/src/microfrontends/users-and-roles/server/scripts/build.js
+++ b/src/microfrontends/users-and-roles/server/scripts/build.js
@@ -4,6 +4,7 @@ const path = require('path');
 const projectRoot = __dirname;
 const distDir = path.resolve(projectRoot, '..', 'dist');
 const filesToCopy = ['server.js'];
+const directoriesToCopy = ['data', 'swagger'];
 
 const ensureDist = () => {
   if (fs.existsSync(distDir)) {
@@ -13,8 +14,26 @@ const ensureDist = () => {
   fs.mkdirSync(distDir, { recursive: true });
 };
 
-const copy = (source, destination) => {
+const copyFile = (source, destination) => {
   fs.copyFileSync(source, destination);
+};
+
+const copyDirectory = (source, destination) => {
+  if (!fs.existsSync(destination)) {
+    fs.mkdirSync(destination, { recursive: true });
+  }
+
+  for (const entry of fs.readdirSync(source)) {
+    const sourceEntry = path.join(source, entry);
+    const destinationEntry = path.join(destination, entry);
+    const stats = fs.statSync(sourceEntry);
+
+    if (stats.isDirectory()) {
+      copyDirectory(sourceEntry, destinationEntry);
+    } else {
+      fs.copyFileSync(sourceEntry, destinationEntry);
+    }
+  }
 };
 
 const build = () => {
@@ -24,7 +43,14 @@ const build = () => {
     const source = path.resolve(projectRoot, '..', file);
     const destination = path.join(distDir, file);
     if (fs.existsSync(source)) {
-      copy(source, destination);
+      copyFile(source, destination);
+    }
+  }
+
+  for (const directory of directoriesToCopy) {
+    const source = path.resolve(projectRoot, '..', directory);
+    if (fs.existsSync(source)) {
+      copyDirectory(source, path.join(distDir, directory));
     }
   }
 

--- a/src/microfrontends/users-and-roles/server/scripts/start-dist.js
+++ b/src/microfrontends/users-and-roles/server/scripts/start-dist.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const distEntry = path.resolve(__dirname, '..', 'dist', 'server.js');
+
+if (!fs.existsSync(distEntry)) {
+  console.error(
+    'Users and roles server build output not found. Please run "npm run build" first.',
+  );
+  process.exit(1);
+}
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+require(distEntry);

--- a/src/microfrontends/users-and-roles/server/server.js
+++ b/src/microfrontends/users-and-roles/server/server.js
@@ -1,13 +1,20 @@
 const path = require('path');
 
-require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+const resolveServerRoot = (directory) =>
+  path.basename(directory) === 'dist' ? path.resolve(directory, '..') : directory;
+
+const SERVER_DIR = resolveServerRoot(__dirname);
+const PROJECT_ROOT = path.resolve(SERVER_DIR, '..');
+const COMMON_ROOT = path.resolve(PROJECT_ROOT, '..', 'common');
+
+require('dotenv').config({ path: path.resolve(PROJECT_ROOT, '.env') });
 
 const express = require('express');
-const manifest = require('../manifest.json');
+const manifest = require(path.resolve(PROJECT_ROOT, 'manifest.json'));
 const {
   buildMicrofrontendDescriptor,
   createMicrofrontendAcknowledger,
-} = require('../../common/bootstrap');
+} = require(path.resolve(COMMON_ROOT, 'bootstrap.js'));
 const {
   createRequestLogger,
   createResponseDelayMiddleware,
@@ -16,10 +23,14 @@ const {
   registerClientAssetHandling,
   resolveClientDevServerUrl,
   resolveClientDistDirectory,
-} = require('../../common/server');
+} = require(path.resolve(COMMON_ROOT, 'server'));
 const swaggerUi = require('swagger-ui-express');
-const apiDocumentation = require('./swagger/users-api.json');
-const { users } = require('./data/users');
+const apiDocumentation = require(path.resolve(
+  SERVER_DIR,
+  'swagger',
+  'users-api.json',
+));
+const { users } = require(path.resolve(SERVER_DIR, 'data', 'users.js'));
 
 const MICROFRONT_PORT = parsePort(process.env.MICROFRONT_PORT, 4402);
 const MICROFRONT_HOST = String(process.env.MICROFRONT_HOST ?? '0.0.0.0');
@@ -39,7 +50,7 @@ const CLIENT_DEV_SERVER_URL = resolveClientDevServerUrl({
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,
-  serverDir: __dirname,
+  serverDir: SERVER_DIR,
 });
 
 const app = express();

--- a/src/shell-app/server/lib/env.js
+++ b/src/shell-app/server/lib/env.js
@@ -51,12 +51,16 @@ const parseProxyTarget = (value) => {
   }
 };
 
+const resolveServerRoot = (serverDir) =>
+  path.basename(serverDir) === 'dist' ? path.resolve(serverDir, '..') : serverDir;
+
 const resolveClientDistDirectory = ({ explicitDistPath, serverDir }) => {
+  const normalizedServerDir = resolveServerRoot(serverDir);
   if (explicitDistPath) {
-    return path.resolve(explicitDistPath);
+    return path.resolve(normalizedServerDir, explicitDistPath);
   }
 
-  return path.resolve(serverDir, '..', 'client', 'dist');
+  return path.resolve(normalizedServerDir, '..', 'client', 'dist');
 };
 
 const createEnvironment = ({ env, serverDir }) => {
@@ -96,4 +100,5 @@ module.exports = {
   parseProxyTarget,
   resolveClientDevServerUrl,
   resolveClientDistDirectory,
+  resolveServerRoot,
 };

--- a/src/shell-app/server/package.json
+++ b/src/shell-app/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "start": "node shell-server.js",
+    "start:dist": "node scripts/start-dist.js",
     "dev": "nodemon --watch shell-server.js --watch data --ext js,json --exec node shell-server.js"
   },
   "dependencies": {

--- a/src/shell-app/server/project.json
+++ b/src/shell-app/server/project.json
@@ -17,6 +17,13 @@
         "cwd": "src/shell-app/server",
         "command": "npm run dev"
       }
+    },
+    "serve-dist": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "src/shell-app/server",
+        "command": "npm run start:dist"
+      }
     }
   },
   "tags": []

--- a/src/shell-app/server/scripts/build.js
+++ b/src/shell-app/server/scripts/build.js
@@ -4,7 +4,7 @@ const path = require('path');
 const projectRoot = __dirname;
 const distDir = path.resolve(projectRoot, '..', 'dist');
 const filesToCopy = ['shell-server.js'];
-const directoriesToCopy = ['data'];
+const directoriesToCopy = ['data', 'lib', 'swagger'];
 
 const copyFile = (source, destination) => {
   fs.copyFileSync(source, destination);

--- a/src/shell-app/server/scripts/start-dist.js
+++ b/src/shell-app/server/scripts/start-dist.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const distEntry = path.resolve(__dirname, '..', 'dist', 'shell-server.js');
+
+if (!fs.existsSync(distEntry)) {
+  console.error('Shell server build output not found. Please run "npm run build" first.');
+  process.exit(1);
+}
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+
+require(distEntry);

--- a/src/shell-app/server/shell-server.js
+++ b/src/shell-app/server/shell-server.js
@@ -1,43 +1,63 @@
 const path = require('path');
 
-require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+const resolveServerRoot = (directory) =>
+  path.basename(directory) === 'dist' ? path.resolve(directory, '..') : directory;
+
+const serverRoot = resolveServerRoot(__dirname);
+const shellRoot = path.resolve(serverRoot, '..');
+const srcRoot = path.resolve(shellRoot, '..');
+const microfrontendsRoot = path.resolve(srcRoot, 'microfrontends');
+
+require('dotenv').config({ path: path.resolve(shellRoot, '.env') });
 
 const express = require('express');
 const swaggerUi = require('swagger-ui-express');
-const { initializationPlan } = require('./data/initialization-plan');
-const { dashboardData } = require('./data/dashboard');
-const { createEnvironment } = require('./lib/env');
-const { createRequestLogger } = require('./lib/request-logger');
-const { createMicrofrontendProxyManager } = require('./lib/microfrontend-proxy');
-const { registerFilteredProxy } = require('../../server/lib/filtered-proxy');
+const { initializationPlan } = require(path.resolve(
+  serverRoot,
+  'data',
+  'initialization-plan.js',
+));
+const { dashboardData } = require(path.resolve(serverRoot, 'data', 'dashboard.js'));
+const { createEnvironment } = require(path.resolve(serverRoot, 'lib', 'env.js'));
+const { createRequestLogger } = require(path.resolve(serverRoot, 'lib', 'request-logger.js'));
+const { createMicrofrontendProxyManager } = require(path.resolve(
+  serverRoot,
+  'lib',
+  'microfrontend-proxy.js',
+));
+const { registerFilteredProxy } = require(path.resolve(
+  srcRoot,
+  'server',
+  'lib',
+  'filtered-proxy.js',
+));
 const {
   createMicrofrontendRegistry,
   sanitizeRegistryEntry,
-} = require('./lib/registry');
-const { cloneDeep, delay } = require('./lib/utils');
+} = require(path.resolve(serverRoot, 'lib', 'registry.js'));
+const { cloneDeep, delay } = require(path.resolve(serverRoot, 'lib', 'utils.js'));
 
-const microfrontendsRoot = path.resolve(__dirname, '..', '..', 'microfrontends');
-const { users } = require(path.join(
+const { users } = require(path.resolve(
   microfrontendsRoot,
   'users-and-roles',
   'server',
   'data',
   'users.js',
 ));
-const { reports } = require(path.join(
+const { reports } = require(path.resolve(
   microfrontendsRoot,
   'operations-reports',
   'server',
   'data',
   'reports.js',
 ));
-const shellApiDocumentation = require('./swagger/shell-api.json');
+const shellApiDocumentation = require(path.resolve(serverRoot, 'swagger', 'shell-api.json'));
 
-const environment = createEnvironment({ env: process.env, serverDir: __dirname });
+const environment = createEnvironment({ env: process.env, serverDir: serverRoot });
 
 const registry = createMicrofrontendRegistry({
-  dataFile: path.join(__dirname, 'dist', 'data', 'microfrontends.json'),
-  sourceDataFile: path.join(__dirname, 'data', 'microfrontends.json'),
+  dataFile: path.join(serverRoot, 'dist', 'data', 'microfrontends.json'),
+  sourceDataFile: path.join(serverRoot, 'data', 'microfrontends.json'),
 });
 
 const initializationPlanById = new Map(initializationPlan.map((step) => [step.id, step]));


### PR DESCRIPTION
## Summary
- add a root build:prod:run helper that builds all apps and launches their dist servers in parallel via Nx
- extend each shell and microfrontend server package with a start:dist script, Nx target, and build updates so the dist bundle contains required assets
- normalize server runtime paths so the dist bundles can locate shared resources when executed from the build output

## Testing
- npm run build --workspace=@enterprise/shell-server
- npm run build --workspace=@enterprise/operations-reports-server
- npm run build --workspace=@enterprise/users-and-roles-server
- npm run start:dist --workspace=@enterprise/shell-server


------
https://chatgpt.com/codex/tasks/task_e_68e2891e939483249ac009db2ff0e769