### PR TITLE
Streamline memlab automation and fix prod microfrontend assets

### DIFF
--- a/src/microfrontends/operations-reports/server/server.js
+++ b/src/microfrontends/operations-reports/server/server.js
@@ -35,18 +35,26 @@ const { reports } = require(path.resolve(SERVER_DIR, 'data', 'reports.js'));
 const MICROFRONT_PORT = parsePort(process.env.MICROFRONT_PORT, 4400);
 const MICROFRONT_HOST = String(process.env.MICROFRONT_HOST ?? '0.0.0.0');
 const SHELL_URL = process.env.SHELL_URL || 'http://localhost:4300';
-const MICROFRONT_PUBLIC_URL = process.env.MICROFRONT_PUBLIC_URL || 'http://localhost:4401';
 const MICROFRONT_API_URL =
   process.env.MICROFRONT_API_URL || `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`;
 const ACK_INTERVAL = Number(process.env.MICROFRONT_ACK_INTERVAL || 30000);
 const isProduction = process.env.NODE_ENV === 'production';
 const CLIENT_HOST = String(process.env.CLIENT_HOST ?? '0.0.0.0');
 const CLIENT_PORT = parsePort(process.env.CLIENT_PORT, 4401);
-const CLIENT_DEV_SERVER_URL = resolveClientDevServerUrl({
-  explicitUrl: process.env.CLIENT_DEV_SERVER_URL,
-  host: CLIENT_HOST,
-  port: CLIENT_PORT,
-});
+const CLIENT_DEV_SERVER_URL = isProduction
+  ? undefined
+  : resolveClientDevServerUrl({
+      explicitUrl: process.env.CLIENT_DEV_SERVER_URL,
+      host: CLIENT_HOST,
+      port: CLIENT_PORT,
+    });
+
+const defaultPublicUrl = isProduction
+  ? `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`
+  : `http://${normalizeHost(CLIENT_HOST)}:${CLIENT_PORT}`;
+
+const MICROFRONT_PUBLIC_URL =
+  process.env.MICROFRONT_PUBLIC_URL?.trim() || defaultPublicUrl;
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,

--- a/src/microfrontends/users-and-roles/server/server.js
+++ b/src/microfrontends/users-and-roles/server/server.js
@@ -35,18 +35,26 @@ const { users } = require(path.resolve(SERVER_DIR, 'data', 'users.js'));
 const MICROFRONT_PORT = parsePort(process.env.MICROFRONT_PORT, 4402);
 const MICROFRONT_HOST = String(process.env.MICROFRONT_HOST ?? '0.0.0.0');
 const SHELL_URL = process.env.SHELL_URL || 'http://localhost:4300';
-const MICROFRONT_PUBLIC_URL = process.env.MICROFRONT_PUBLIC_URL || 'http://localhost:4403';
 const MICROFRONT_API_URL =
   process.env.MICROFRONT_API_URL || `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`;
 const ACK_INTERVAL = Number(process.env.MICROFRONT_ACK_INTERVAL || 30000);
 const isProduction = process.env.NODE_ENV === 'production';
 const CLIENT_HOST = String(process.env.CLIENT_HOST ?? '0.0.0.0');
 const CLIENT_PORT = parsePort(process.env.CLIENT_PORT, 4403);
-const CLIENT_DEV_SERVER_URL = resolveClientDevServerUrl({
-  explicitUrl: process.env.CLIENT_DEV_SERVER_URL,
-  host: CLIENT_HOST,
-  port: CLIENT_PORT,
-});
+const CLIENT_DEV_SERVER_URL = isProduction
+  ? undefined
+  : resolveClientDevServerUrl({
+      explicitUrl: process.env.CLIENT_DEV_SERVER_URL,
+      host: CLIENT_HOST,
+      port: CLIENT_PORT,
+    });
+
+const defaultPublicUrl = isProduction
+  ? `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`
+  : `http://${normalizeHost(CLIENT_HOST)}:${CLIENT_PORT}`;
+
+const MICROFRONT_PUBLIC_URL =
+  process.env.MICROFRONT_PUBLIC_URL?.trim() || defaultPublicUrl;
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,

--- a/src/shell-app/client/components/MainLayout.tsx
+++ b/src/shell-app/client/components/MainLayout.tsx
@@ -351,7 +351,7 @@ const MainLayout: React.FC = () => {
       path: '/',
       element: <Navigate to="/dashboard" replace />,
     },
-    { 
+    {
       path: '/dashboard',
       Component: Dashboard,
     },

--- a/tests/memlab/device-security.scenario.js
+++ b/tests/memlab/device-security.scenario.js
@@ -13,82 +13,146 @@ function getBaseUrl() {
 
 function url() {
   const baseUrl = getBaseUrl();
-  return `${baseUrl}/dashboard`;
+  return `${baseUrl}/device-security`;
 }
 
 async function waitForTableReady(page) {
-  await page.waitForSelector('text/Безопасность устройств', { timeout: 30000 });
-  await page.waitForSelector('.ant-table-wrapper', { timeout: 10000 });
-  await page.waitForSelector('.ant-pagination', { timeout: 10000 });
-  await page.waitForSelector('.ant-table-row', { timeout: 10000 });
-}
-
-async function goToDeviceSecurity(page) {
-  const baseUrl = getBaseUrl();
-  await page.goto(`${baseUrl}/device-security`, { waitUntil: 'networkidle0' });
-  await waitForTableReady(page);
+  await page.waitForSelector('[data-test="device-security-title"]', { timeout: 30000 });
+  await page.waitForSelector('[data-test="device-security-table"]', { timeout: 10000 });
+  await page.waitForSelector('[data-test="device-security-pagination-next"]', { timeout: 10000 });
+  await page.waitForSelector('[data-test="device-security-row"]', { timeout: 10000 });
 }
 
 async function advanceToLastPage(page) {
   let safeguard = 0;
 
   while (safeguard < 100) {
-    await page.waitForSelector('li.ant-pagination-next button', { timeout: 10000 });
+    await page.waitForSelector('[data-test="device-security-pagination-next"]', { timeout: 10000 });
 
-    const isDisabled = await page.$eval('li.ant-pagination-next button', (element) => {
-      return element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true';
-    });
+    const isDisabled = await page.$eval(
+      '[data-test="device-security-pagination-next"]',
+      (element) => {
+        if (element.hasAttribute('disabled')) {
+          return true;
+        }
+
+        const ariaDisabled = element.getAttribute('aria-disabled');
+        if (ariaDisabled === 'true') {
+          return true;
+        }
+
+        const closestDisabled = element.closest('[aria-disabled="true"]');
+        return Boolean(closestDisabled);
+      },
+    );
 
     if (isDisabled) {
       break;
     }
 
-    const currentPage = await page.$eval('.ant-pagination-item-active', (element) => {
-      const text = element.textContent || '';
-      const parsed = Number.parseInt(text.trim(), 10);
-      return Number.isFinite(parsed) ? parsed : 0;
-    });
+    const currentPage = await page.evaluate(() => {
+      const items = Array.from(
+        document.querySelectorAll('[data-test^="device-security-pagination-item-"]'),
+      );
 
-    await page.click('li.ant-pagination-next button');
-
-    await page.waitForFunction(
-      (expected) => {
-        const active = document.querySelector('.ant-pagination-item-active');
-        if (!active) {
-          return false;
+      for (const item of items) {
+        const parent = item.closest('[aria-current="page"]');
+        if (!parent) {
+          continue;
         }
 
-        const text = active.textContent || '';
+        const text = item.textContent || '';
         const parsed = Number.parseInt(text.trim(), 10);
-        return Number.isFinite(parsed) && parsed >= expected;
+        if (Number.isFinite(parsed)) {
+          return parsed;
+        }
+      }
+
+      return 0;
+    });
+
+    await page.click('[data-test="device-security-pagination-next"]');
+
+    await page.waitForFunction(
+      (expectedPage, selectorPrefix) => {
+        const items = Array.from(
+          document.querySelectorAll(`[data-test^="${selectorPrefix}"]`),
+        );
+
+        return items.some((item) => {
+          const parent = item.closest('[aria-current="page"]');
+          if (!parent) {
+            return false;
+          }
+
+          const text = item.textContent || '';
+          const parsed = Number.parseInt(text.trim(), 10);
+          return Number.isFinite(parsed) && parsed >= expectedPage;
+        });
       },
       { timeout: 10000 },
       currentPage + 1,
+      'device-security-pagination-item-',
     );
 
     safeguard += 1;
   }
 
   await page.waitForFunction(() => {
-    const element = document.querySelector('li.ant-pagination-next button');
+    const element = document.querySelector('[data-test="device-security-pagination-next"]');
     if (!element) {
       return false;
     }
 
-    return element.hasAttribute('disabled') || element.getAttribute('aria-disabled') === 'true';
+    if (element.hasAttribute('disabled')) {
+      return true;
+    }
+
+    if (element.getAttribute('aria-disabled') === 'true') {
+      return true;
+    }
+
+    return Boolean(element.closest('[aria-disabled="true"]'));
   });
 }
 
 async function action(page) {
-  await goToDeviceSecurity(page);
+  await waitForTableReady(page);
   await advanceToLastPage(page);
 }
 
 async function back(page) {
-  try {
-    await page.goBack({ waitUntil: 'networkidle0' });
-  } catch (error) {
-    console.warn('Failed to navigate back from device security page.', error);
+  let safeguard = 0;
+
+  while (safeguard < 100) {
+    const hasPrevious = await page.$('[data-test="device-security-pagination-prev"]');
+    if (!hasPrevious) {
+      break;
+    }
+
+    const isDisabled = await page.$eval(
+      '[data-test="device-security-pagination-prev"]',
+      (element) => {
+        if (element.hasAttribute('disabled')) {
+          return true;
+        }
+
+        if (element.getAttribute('aria-disabled') === 'true') {
+          return true;
+        }
+
+        return Boolean(element.closest('[aria-disabled="true"]'));
+      },
+    );
+
+    if (isDisabled) {
+      break;
+    }
+
+    await page.click('[data-test="device-security-pagination-prev"]');
+
+    await page.waitForTimeout(250);
+    safeguard += 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the memlab runner to start the production build via `npm run build:prod:run`, support arbitrary scenarios, and allow running in headful mode
- add stable `data-test` hooks to the device security page, and update the memlab scenario to avoid reloads while using those selectors
- ensure production microfrontend servers stop proxying to dev assets and default their public URLs to the server host

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29226e9208324a26e6aaafcf13eb2