### PR TITLE
Ensure production microfrontends ignore public URL override

### DIFF
--- a/src/microfrontends/operations-reports/server/server.js
+++ b/src/microfrontends/operations-reports/server/server.js
@@ -53,8 +53,10 @@ const defaultPublicUrl = isProduction
   ? `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`
   : `http://${normalizeHost(CLIENT_HOST)}:${CLIENT_PORT}`;
 
-const MICROFRONT_PUBLIC_URL =
-  process.env.MICROFRONT_PUBLIC_URL?.trim() || defaultPublicUrl;
+const publicUrlFromEnv = process.env.MICROFRONT_PUBLIC_URL?.trim();
+const MICROFRONT_PUBLIC_URL = isProduction
+  ? defaultPublicUrl
+  : publicUrlFromEnv || defaultPublicUrl;
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,

--- a/src/microfrontends/users-and-roles/server/server.js
+++ b/src/microfrontends/users-and-roles/server/server.js
@@ -53,8 +53,10 @@ const defaultPublicUrl = isProduction
   ? `http://${normalizeHost(MICROFRONT_HOST)}:${MICROFRONT_PORT}`
   : `http://${normalizeHost(CLIENT_HOST)}:${CLIENT_PORT}`;
 
-const MICROFRONT_PUBLIC_URL =
-  process.env.MICROFRONT_PUBLIC_URL?.trim() || defaultPublicUrl;
+const publicUrlFromEnv = process.env.MICROFRONT_PUBLIC_URL?.trim();
+const MICROFRONT_PUBLIC_URL = isProduction
+  ? defaultPublicUrl
+  : publicUrlFromEnv || defaultPublicUrl;
 
 const DIST_DIR = resolveClientDistDirectory({
   explicitDistPath: process.env.CLIENT_DIST_DIR,


### PR DESCRIPTION
## Summary
- ensure microfrontend servers ignore the MICROFRONT_PUBLIC_URL override in production
- fall back to the explicit public URL only in development to avoid stale dev settings in prod

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2997d78a88324a97928a763074ff3